### PR TITLE
Multiple main threads, instead of single master thread

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-Queue.o
+*.o
 evalqueue

--- a/Queue.cpp
+++ b/Queue.cpp
@@ -1,6 +1,7 @@
 #include "Queue.hpp"
 
-#include <unistd.h> // For usleep
+#include <algorithm>    // For sort
+#include <unistd.h>     // For usleep
 
 omp_lock_t _queueLock;
 
@@ -24,8 +25,10 @@ void Queue::addToQueue(const QueuePointPtr point)
 
 void Queue::stopAdding()
 {
-    // TODO: Here, sort queue.
     omp_unset_lock(&_queueLock);
+    // sort queue
+    LowerPriority comp;
+    sort(comp);
 }
 
 
@@ -94,6 +97,19 @@ bool Queue::run()
     std::cout << "Thread " << omp_get_thread_num() << " is out of while loop" << std::endl;
 
     return successFound;
+}
+
+
+void Queue::sort(LowerPriority comp)
+{
+    if (!_queue.empty())
+    {
+        omp_set_lock(&_queueLock);
+
+        std::sort(_queue.begin(), _queue.end(), comp);
+
+        omp_unset_lock(&_queueLock);
+    }
 }
 
 
@@ -170,7 +186,9 @@ void Queue::setAllP1ToFalse()
             point->setP1(false);
             _queue.push_back(point);
         }
-        // VRM TODO sort queue here? / rewrite this method since we don't use a priority_queue anymore.
+        // re-sort queue
+        LowerPriority comp;
+        sort(comp);
     }
     //omp_unset_lock(&_queueLock);
 }

--- a/Queue.cpp
+++ b/Queue.cpp
@@ -27,8 +27,7 @@ void Queue::stopAdding()
 {
     omp_unset_lock(&_queueLock);
     // sort queue
-    LowerPriority comp;
-    sort(comp);
+    sort();
 }
 
 
@@ -187,8 +186,7 @@ void Queue::setAllP1ToFalse()
             _queue.push_back(point);
         }
         // re-sort queue
-        LowerPriority comp;
-        sort(comp);
+        sort();
     }
     //omp_unset_lock(&_queueLock);
 }

--- a/Queue.cpp
+++ b/Queue.cpp
@@ -83,7 +83,10 @@ bool Queue::run()
     // conditionForStop is true if we are in a main thread and stopMainEval() returns true.
     while (!conditionForStop && !_doneWithEval)
     {
-        std::cout << "In Queue::run(). Thread: " << omp_get_thread_num() << std::endl;
+        #pragma omp critical(printInfo)
+        {
+            std::cout << "In Queue::run(). Thread: " << omp_get_thread_num() << std::endl;
+        }
         // Check for stop conditions
         if (isMainThread(omp_get_thread_num()))
         {
@@ -97,7 +100,10 @@ bool Queue::run()
         }
         else if (!_doneWithEval)
         {
-            std::cout << "Thread: " << omp_get_thread_num() << " Waiting for points." << std::endl;
+            #pragma omp critical(printInfo)
+            {
+                std::cout << "Thread: " << omp_get_thread_num() << " Waiting for points." << std::endl;
+            }
         }
         else // Queue is empty and we are doneWithEval
         {
@@ -107,7 +113,10 @@ bool Queue::run()
         usleep(100000);
     }   // End of while loop: Exit for main threads.
         // Other threads keep on looping.
-    std::cout << "Thread " << omp_get_thread_num() << " is out of while loop" << std::endl;
+    #pragma omp critical(printInfo)
+    {
+        std::cout << "Thread " << omp_get_thread_num() << " is out of while loop" << std::endl;
+    }
 
     return successFound;
 }
@@ -165,12 +174,18 @@ bool Queue::evalSinglePoint()
     {
         // Eval is between 1 and 50
         double eval = 1+std::rand()/((RAND_MAX + 1u)/50);
-        //std::cout << "In thread: " << omp_get_thread_num() << " Eval point " << *point << " to " << eval << std::endl;
+        #pragma omp critical(printInfo)
+        {
+            std::cout << "In thread: " << omp_get_thread_num() << " Eval point " << *point << " to " << eval << std::endl;
+        }
         point->setEval(eval);
         if (eval < point->getBestEval())
         {
             success = true;
-            std::cout << "Thread " << omp_get_thread_num() << ". New success found: " << *point << std::endl;
+            #pragma omp critical(printInfo)
+            {
+                std::cout << "Thread " << omp_get_thread_num() << ". New success found: " << *point << std::endl;
+            }
             // In NOMAD, we would update new point's best eval to this value.
             // Not done here - best eval is static.
         }
@@ -220,7 +235,10 @@ void Queue::setAllP1ToFalse()
         QueuePointPtr point;
         while (getTopPoint()->getP1() && popPoint(point))
         {
-            std::cout << "Pop P1" << std::endl;
+            #pragma omp critical(printInfo)
+            {
+                std::cout << "Pop P1" << std::endl;
+            }
             point->setP1(false);
             _queue.push_back(point);
         }
@@ -247,7 +265,10 @@ void Queue::displayAndClear()
     QueuePointPtr point;
     while (!_queue.empty() && popPoint(point))
     {
-        std::cout << *point << std::endl;
+        #pragma omp critical(printInfo)
+        {
+            std::cout << *point << std::endl;
+        }
     }
     //omp_unset_lock(&_queueLock);
 }

--- a/Queue.cpp
+++ b/Queue.cpp
@@ -126,6 +126,10 @@ void Queue::stop()
 {
     int threadNum = omp_get_thread_num();
     _mainThreadInfo.at(threadNum).setDoneWithEval(true);
+    #pragma omp critical(printInfo)
+    {
+        std::cout << "Queue::stop: Stop main thread " << threadNum << "." << std::endl;
+    }
 
     // Go through all main thread info to see if _doneWithEval must be set.
     // This part is not optimized, we can probably do better, but it does not 
@@ -136,11 +140,20 @@ void Queue::stop()
         if (allDone && !_mainThreadInfo.at(mainThreadNum).getDoneWithEval())
         {
             allDone = false;
+            #pragma omp critical(printInfo)
+            {
+                std::cout << "Queue::stop: Not done with queue because thread " << mainThreadNum << " is not done." << std::endl;
+            }
+            break;
         }
     }
 
     if (allDone)
     {
+        #pragma omp critical(printInfo)
+        {
+            std::cout << "Queue::stop: All main threads done. Done with queue." << std::endl;
+        }
         _doneWithEval = true;
     }
 

--- a/Queue.hpp
+++ b/Queue.hpp
@@ -2,26 +2,27 @@
 #ifndef __QUEUE_HPP__
 #define __QUEUE_HPP__
 
-#include <queue>        // For priority_queue
+#include <vector>
 
 #include "QueuePoint.hpp"
+
+class MainThreadInfo
+{
+};
 
 class Queue
 {
 private:
     // The Queue of Points
-    std::priority_queue<QueuePointPtr, 
-                        std::vector<QueuePointPtr>,
-                        LowerPriority> _queue;
+    std::vector<QueuePointPtr> _queue;
     bool _doneWithEval;         // All evaluations done. Queue can be destroyed.
-    //static int _sLocksForAdd;   // When we add, we do not want to eval.
-    omp_lock_t _lockForAdd;     // When we add, we do not want to eval.
+    mutable omp_lock_t _lockForAdd;     // When we add, we do not want to eval.
 
 
 public:
     // Constructor
-    explicit Queue(LowerPriority lowerPriority)
-      : _queue(lowerPriority),
+    explicit Queue()
+      : _queue(),
         _doneWithEval(false),
         _lockForAdd()
     {
@@ -64,11 +65,13 @@ public:
     // Add a single Point to the Queue
     void addToQueue(const QueuePointPtr point);
 
+    QueuePointPtr getTopPoint() const;
+
     // get the top Point from the queue and pop it.
     // Return true if it worked, false otherwise.
     bool popPoint(QueuePointPtr &point);
 
-    // Display all points in the queue, in order of priority.
+    // Display all points in the queue
     // Clear it at the same time.
     void displayAndClear();
 

--- a/Queue.hpp
+++ b/Queue.hpp
@@ -15,8 +15,8 @@ class Queue
 private:
     // The Queue of Points
     std::vector<QueuePointPtr> _queue;
-    bool _doneWithEval;         // All evaluations done. Queue can be destroyed.
-    mutable omp_lock_t _lockForAdd;     // When we add, we do not want to eval.
+    bool _doneWithEval;             // All evaluations done. Queue can be destroyed.
+    mutable omp_lock_t _queueLock;  // Do not launch new evaluations when queue is locked, e.g. for adding points.
 
 
 public:
@@ -24,16 +24,16 @@ public:
     explicit Queue()
       : _queue(),
         _doneWithEval(false),
-        _lockForAdd()
+        _queueLock()
     {
-        omp_init_lock(&_lockForAdd);
+        omp_init_lock(&_queueLock);
         //run();    // Do not start queue here: wait until we are in parallel zone.
     }
 
     // Destructor, could be needed to destroy lock.
     virtual ~Queue()
     {
-        omp_destroy_lock(&_lockForAdd);
+        omp_destroy_lock(&_queueLock);
     }
 
     // Get/Set

--- a/Queue.hpp
+++ b/Queue.hpp
@@ -73,7 +73,7 @@ public:
     }
     bool isMainThread(const int threadNum) const { return (_mainThreads.end() != _mainThreads.find(threadNum)); }
     const std::set<int>& getMainThreads() const { return _mainThreads; }
-    size_t getNbMainThreads() const { return _mainThreads.size(); }
+    int getNbMainThreads() const { return int(_mainThreads.size()); }
 
     // Other methods
 

--- a/Queue.hpp
+++ b/Queue.hpp
@@ -2,98 +2,12 @@
 #ifndef __QUEUE_HPP__
 #define __QUEUE_HPP__
 
-#include <functional>   // For std::function
-#include <iostream>
-#include <memory>       // For shared_ptr
-#include <omp.h>
 #include <queue>        // For priority_queue
 
-class QueuePoint
+#include "QueuePoint.hpp"
+
+class Queue
 {
-private:
-    // In fact, the QueuePoint must have a pointer to some kind
-    // of point (e.g. EvalPoint), not replicate its members.
-    // I.e. _x,_y but also _eval should be hidden, and the _comp
-    // of the Queue is related to that outside point class.
-    // Not sure where _bestEval would reside.
-    // _P1 remains here.
-
-    // Point has 2 coordinates
-    double  _x;
-    double  _y;
-    // Value of evaluation
-    double _eval;
-    // Value to which evaluation will be compared
-    double  _bestEval;
-    // Is this a "priority 1" point to eval?
-    // P1 points are always evaluated first, and the algorithm
-    // only continues when all P1 points are evaluated / or when
-    // a success is found.
-    bool _P1;
-
-public:
-    QueuePoint(double x, double y, double bestEval)
-      : _x(x),
-        _y(y),
-        _eval(0),
-        _bestEval(bestEval),
-        _P1(false)
-    {}
-
-    // Get/Set
-    double getX() const { return _x; }
-    double getY() const { return _y; }
-    double getEval() const { return _eval; }
-    void setEval(const double eval) { _eval = eval; }
-    double getBestEval() const { return _bestEval; }
-    void setP1(const bool p1) { _P1 = p1; }
-    bool getP1() const { return _P1; }
-
-};
-
-typedef std::shared_ptr<QueuePoint> QueuePointPtr;
-
-std::ostream& operator<<(std::ostream& out, const QueuePoint& point);
-
-
-class LowerPriority {
-private:
-    std::function<bool(QueuePointPtr &p1, QueuePointPtr &p2)> _comp;
-
-public:
-    // Constructor
-    LowerPriority(const std::function<bool(QueuePointPtr &p1, QueuePointPtr &p2)> comp = std::function<bool(QueuePointPtr &p1, QueuePointPtr &p2)>(DefaultComp))
-      : _comp(comp)
-    {}
-
-
-    // Comparison operator for sorting queue points (at insertion).
-    // Points P1 are always prioritary.
-    bool operator()(QueuePointPtr& p1, QueuePointPtr& p2)
-    {
-        bool hasLowerPriority = false;
-        
-        if (p1->getP1() != p2->getP1())
-        {
-            hasLowerPriority = (p1->getP1() < p2->getP1());
-        }
-        else
-        {
-            hasLowerPriority = _comp(p1, p2);
-        }
-
-        return hasLowerPriority;
-    }
-
-    // Priority is lower if evaluation is higher.
-    static bool DefaultComp(QueuePointPtr& p1, QueuePointPtr& p2)
-    {
-        return (p1->getBestEval() > p2->getBestEval());
-    }
-};
-
-
-class Queue {
 private:
     // The Queue of Points
     std::priority_queue<QueuePointPtr, 

--- a/Queue.hpp
+++ b/Queue.hpp
@@ -48,6 +48,9 @@ public:
     // Stop evaluation
     void stop() { _doneWithEval = true; }
 
+    /// Sort the queue with respect to the comparison function comp.
+    void sort(LowerPriority comp);
+  
     // Eval a single point (mock eval). Pop it from queue.
     // Return true (success) if eval is better than point's best eval.
     bool evalSinglePoint();

--- a/Queue.hpp
+++ b/Queue.hpp
@@ -15,14 +15,16 @@ class Queue
 private:
     // The Queue of Points
     std::vector<QueuePointPtr> _queue;
+    LowerPriority _comp;            // Comparison function used for sorting
     bool _doneWithEval;             // All evaluations done. Queue can be destroyed.
     mutable omp_lock_t _queueLock;  // Do not launch new evaluations when queue is locked, e.g. for adding points.
 
 
 public:
     // Constructor
-    explicit Queue()
+    explicit Queue(LowerPriority comp)
       : _queue(),
+        _comp(comp),
         _doneWithEval(false),
         _queueLock()
     {
@@ -50,6 +52,9 @@ public:
 
     /// Sort the queue with respect to the comparison function comp.
     void sort(LowerPriority comp);
+
+    /// Use the default comparison function _comp.
+    void sort() { sort(_comp); }
   
     // Eval a single point (mock eval). Pop it from queue.
     // Return true (success) if eval is better than point's best eval.

--- a/QueuePoint.cpp
+++ b/QueuePoint.cpp
@@ -1,0 +1,2 @@
+#include "QueuePoint.hpp"
+

--- a/QueuePoint.hpp
+++ b/QueuePoint.hpp
@@ -66,7 +66,7 @@ public:
     {}
 
 
-    // Comparison operator for sorting queue points (at insertion).
+    // Comparison operator for sorting queue points.
     // Points P1 are always prioritary.
     bool operator()(QueuePointPtr& p1, QueuePointPtr& p2)
     {

--- a/QueuePoint.hpp
+++ b/QueuePoint.hpp
@@ -1,0 +1,95 @@
+
+#ifndef __QUEUEPOINT_HPP__
+#define __QUEUEPOINT_HPP__
+
+#include <functional>   // For std::function
+#include <iostream>
+#include <memory>       // For shared_ptr
+#include <omp.h>
+
+class QueuePoint
+{
+private:
+    // In fact, the QueuePoint must have a pointer to some kind
+    // of point (e.g. EvalPoint), not replicate its members.
+    // I.e. _x,_y but also _eval should be hidden, and the _comp
+    // of the Queue is related to that outside point class.
+    // Not sure where _bestEval would reside.
+    // _P1 remains here.
+
+    // Point has 2 coordinates
+    double  _x;
+    double  _y;
+    // Value of evaluation
+    double _eval;
+    // Value to which evaluation will be compared
+    double  _bestEval;
+    // Is this a "priority 1" point to eval?
+    // P1 points are always evaluated first, and the algorithm
+    // only continues when all P1 points are evaluated / or when
+    // a success is found.
+    bool _P1;
+
+public:
+    QueuePoint(double x, double y, double bestEval)
+      : _x(x),
+        _y(y),
+        _eval(0),
+        _bestEval(bestEval),
+        _P1(false)
+    {}
+
+    // Get/Set
+    double getX() const { return _x; }
+    double getY() const { return _y; }
+    double getEval() const { return _eval; }
+    void setEval(const double eval) { _eval = eval; }
+    double getBestEval() const { return _bestEval; }
+    void setP1(const bool p1) { _P1 = p1; }
+    bool getP1() const { return _P1; }
+
+};
+
+typedef std::shared_ptr<QueuePoint> QueuePointPtr;
+
+std::ostream& operator<<(std::ostream& out, const QueuePoint& point);
+
+
+class LowerPriority {
+private:
+    std::function<bool(QueuePointPtr &p1, QueuePointPtr &p2)> _comp;
+
+public:
+    // Constructor
+    LowerPriority(const std::function<bool(QueuePointPtr &p1, QueuePointPtr &p2)> comp = std::function<bool(QueuePointPtr &p1, QueuePointPtr &p2)>(DefaultComp))
+      : _comp(comp)
+    {}
+
+
+    // Comparison operator for sorting queue points (at insertion).
+    // Points P1 are always prioritary.
+    bool operator()(QueuePointPtr& p1, QueuePointPtr& p2)
+    {
+        bool hasLowerPriority = false;
+        
+        if (p1->getP1() != p2->getP1())
+        {
+            hasLowerPriority = (p1->getP1() < p2->getP1());
+        }
+        else
+        {
+            hasLowerPriority = _comp(p1, p2);
+        }
+
+        return hasLowerPriority;
+    }
+
+    // Priority is lower if evaluation is higher.
+    static bool DefaultComp(QueuePointPtr& p1, QueuePointPtr& p2)
+    {
+        return (p1->getBestEval() > p2->getBestEval());
+    }
+};
+
+
+#endif // __QUEUEPOINT_HPP__

--- a/main.cpp
+++ b/main.cpp
@@ -67,8 +67,7 @@ int main(int argc , char **argv)
     // Queue queue(orderByDirection);
     // June 2020: Sorting is now on vector, instead of using a priority_queue, and will be
     // done when stopAdding() is called.
-    Queue queue;
-    queue.sort(orderByDirection);
+    Queue queue(orderByDirection);
     queue.start();
     std::cout << "Start main" << std::endl;
 

--- a/main.cpp
+++ b/main.cpp
@@ -167,7 +167,7 @@ int main(int argc , char **argv)
         // The first nbMainThreads threads that reach this point are considered main threads.
         // The master thread (number 0) has to be in that set.
         int threadNum = omp_get_thread_num();
-        #pragma omp critical(addMainThread)
+        #pragma omp critical(printInfo)
         {
             if (queue.getNbMainThreads() < nbMainThreads)
             {
@@ -231,9 +231,15 @@ int main(int argc , char **argv)
         //#pragma omp barrier
 
         // Launch evaluation on all threads, including master.
-        std::cout << "Launch run for thread " << omp_get_thread_num() << std::endl;
+        #pragma omp critical(printInfo)
+        {
+            std::cout << "Launch run for thread " << omp_get_thread_num() << std::endl;
+        }
         stopEval = queue.run();
-        std::cout << "Done runing for thread " << omp_get_thread_num() << std::endl;
+        #pragma omp critical(printInfo)
+        {
+            std::cout << "Done running for thread " << omp_get_thread_num() << std::endl;
+        }
 
         // From here, only main threads are out of queue.run(). The other
         // threads are waiting for evaluation.
@@ -242,7 +248,10 @@ int main(int argc , char **argv)
         {
             queue.setAllP1ToFalse();
 
-            std::cout << std::endl << "Adding new points..." << std::endl;
+            #pragma omp critical(printInfo)
+            {
+                std::cout << std::endl << "Adding new points..." << std::endl;
+            }
             #pragma omp single nowait
             {
                 queue.startAdding();
@@ -261,11 +270,17 @@ int main(int argc , char **argv)
 
             // All, the threads other than main are still available for evaluation.
             // Re-launch run for main threads only.
-            std::cout << "Launch run for thread " << omp_get_thread_num() << std::endl;
+            #pragma omp critical(printInfo)
+            {
+                std::cout << "Launch run for thread " << omp_get_thread_num() << std::endl;
+            }
             stopEval = queue.run();
 
-            std::cout << "Ready to stop." << std::endl;
-            // Stop queue for this main threads
+            #pragma omp critical(printInfo)
+            {
+                std::cout << "Ready to stop for main thread " << omp_get_thread_num() << std::endl;
+            }
+            // Stop queue for this main thread
             queue.stop();
         }   // End main thread
     }   // End parallel region

--- a/main.cpp
+++ b/main.cpp
@@ -49,24 +49,33 @@ double OrderByDirection::_dirY = 0.0;
 // Calling argument: Number of threads to use.
 int main(int argc , char **argv)
 {
-    const int nbMainThreads = 3;
-    int nbThreads = omp_get_num_threads();
+    int nbThreads = omp_get_max_threads();
+    int nbMainThreads = nbThreads / 3 + 1;
     if (argc > 1)
     {
         nbThreads = std::atoi(argv[1]);
+        nbMainThreads = nbThreads / 3 + 1;
         if (0 == nbThreads)
         {
-            nbThreads = omp_get_num_threads();
+            nbThreads = omp_get_max_threads();
+        }
+        if (argc > 2)
+        {
+            nbMainThreads = std::atoi(argv[2]);
+            if (0 == nbMainThreads)
+            {
+                nbMainThreads = 1;
+            }
         }
     }
     if (nbThreads < nbMainThreads)
     {
-        std::cout << "Warning: number of threads was " << nbThreads << ". Set to " << nbMainThreads*2 << "." << std::endl;
-        nbThreads = nbMainThreads*2;
+        std::cerr << "Error: number of main threads (" << nbMainThreads << ") should be less or equal to number of threads (" << nbThreads << ")." << std::endl;
+        return 1;
     }
     else
     {
-        std::cout << "Working with " << nbThreads << " threads." << std::endl;
+        std::cout << "Working with " << nbMainThreads << " main thread" << (nbMainThreads > 1 ? "s" : "") << " on a total of " << nbThreads << " thread" << (nbThreads > 1 ? "s" : "") << "." << std::endl;
     }
 
     // Create queue for all threads

--- a/main.cpp
+++ b/main.cpp
@@ -150,9 +150,6 @@ int main(int argc , char **argv)
     pP17->setP1(true);
     pP23->setP1(true);
 
-    // Parameters used for all threads
-    int nbEval = 6;
-
     // Start all processes
     #pragma omp parallel num_threads(nbThreads) default(shared)
     {

--- a/main.cpp
+++ b/main.cpp
@@ -231,33 +231,34 @@ int main(int argc , char **argv)
         // So we work on main threads only.
         if (queue.isMainThread(threadNum))
         {
-            /*
             queue.setAllP1ToFalse();
 
             std::cout << std::endl << "Adding new points..." << std::endl;
-            queue.startAdding();
-            for (QueuePointPtr pp : { pP1, pP2, pP3, pP4, pP5, pP6, pP13, pP14, \
+            #pragma omp single nowait
+            {
+                queue.startAdding();
+                for (QueuePointPtr pp : { pP1, pP2, pP3, pP4, pP5, pP6, pP13, pP14, \
                                       pP15, pP16, pP17, pP18, pP19, pP20, pP21, \
                                       pP22, pP23, pP24, pP25, pP26, pP27, pP28, \
                                       pP29, pP30, pP31, pP32, pP33, pP34, pP35, \
                                       pP36, pP37, pP38, pP39, pP40, pP41, pP42, \
                                       pP43, pP44, pP45, pP46, pP47, pP48, pP49
                                       })
-            {
-                queue.addToQueue(pp);
+                {
+                    queue.addToQueue(pp);
+                }
+                queue.stopAdding();
             }
-            queue.stopAdding();
 
-            // All, the threads other than master are still available for evaluation.
-            // Re-launch run for master only.
+            // All, the threads other than main are still available for evaluation.
+            // Re-launch run for main threads only.
             std::cout << "Launch run for thread " << omp_get_thread_num() << std::endl;
             stopEval = queue.run();
-            */
 
             std::cout << "Ready to stop." << std::endl;
-            // Stop queue for all threads
+            // Stop queue for this main threads
             queue.stop();
-        }   // End master thread
+        }   // End main thread
     }   // End parallel region
 
     return 0;

--- a/main.cpp
+++ b/main.cpp
@@ -64,9 +64,8 @@ int main(int argc , char **argv)
     LowerPriority orderByDirection(OrderByDirection::comp);
     OrderByDirection::setDirX(6);
     OrderByDirection::setDirY(-2);
-    // Queue queue(orderByDirection);
-    // June 2020: Sorting is now on vector, instead of using a priority_queue, and will be
-    // done when stopAdding() is called.
+    // June 2020: Queue is now a vector, instead of using a priority_queue.
+    // Sorting is done when stopAdding() is called.
     Queue queue(orderByDirection);
     queue.start();
     std::cout << "Start main" << std::endl;

--- a/main.cpp
+++ b/main.cpp
@@ -62,10 +62,11 @@ int main(int argc , char **argv)
 
     // Create queue for all threads
     LowerPriority orderByDirection(OrderByDirection::comp);
-    //LowerPriority orderDefault(LowerPriority::DefaultComp);
     OrderByDirection::setDirX(6);
     OrderByDirection::setDirY(-2);
-    Queue queue(orderByDirection);
+    //Queue queue(orderByDirection);
+    // TODO: Implement new sorting (on vector, instead of using a priority_queue)
+    Queue queue;
     queue.start();
     std::cout << "Start main" << std::endl;
 

--- a/main.cpp
+++ b/main.cpp
@@ -64,9 +64,11 @@ int main(int argc , char **argv)
     LowerPriority orderByDirection(OrderByDirection::comp);
     OrderByDirection::setDirX(6);
     OrderByDirection::setDirY(-2);
-    //Queue queue(orderByDirection);
-    // TODO: Implement new sorting (on vector, instead of using a priority_queue)
+    // Queue queue(orderByDirection);
+    // June 2020: Sorting is now on vector, instead of using a priority_queue, and will be
+    // done when stopAdding() is called.
     Queue queue;
+    queue.sort(orderByDirection);
     queue.start();
     std::cout << "Start main" << std::endl;
 

--- a/makefile
+++ b/makefile
@@ -1,10 +1,13 @@
 
 all: evalqueue
 
+QueuePoint.o: QueuePoint.cpp QueuePoint.hpp
+	g++ -c QueuePoint.cpp -o QueuePoint.o -fopenmp
+
 Queue.o: Queue.cpp Queue.hpp
 	g++ -c Queue.cpp -o Queue.o -fopenmp
 
-evalqueue: Queue.o main.cpp
+evalqueue: QueuePoint.o Queue.o main.cpp
 	g++ main.cpp Queue.o -o evalqueue -fopenmp
 
 clean:

--- a/makefile
+++ b/makefile
@@ -1,14 +1,16 @@
 
 all: evalqueue
 
+CXXFLAGS = -O2 -Wall -Wextra
+
 QueuePoint.o: QueuePoint.cpp QueuePoint.hpp
-	g++ -c QueuePoint.cpp -o QueuePoint.o -fopenmp
+	g++ $(CXXFLAGS) -c QueuePoint.cpp -o QueuePoint.o -fopenmp
 
 Queue.o: Queue.cpp Queue.hpp
-	g++ -c Queue.cpp -o Queue.o -fopenmp
+	g++ $(CXXFLAGS) -c Queue.cpp -o Queue.o -fopenmp
 
 evalqueue: QueuePoint.o Queue.o main.cpp
-	g++ main.cpp Queue.o -o evalqueue -fopenmp
+	g++ $(CXXFLAGS) main.cpp Queue.o -o evalqueue -fopenmp
 
 clean:
 	rm -f *.o evalqueue


### PR DESCRIPTION
Points may be generated and added from different main threads.
There is still one single queue.
Points are evaluated both in main threads and in secondary threads.
There is one doneWithEval flag for each main thread, and one for the queue, which is set to true when all others are set to true.
Also some clean-up and restructuration to have this queue more like the NOMAD 4 queue.